### PR TITLE
PAPILIO-72 General Feeds

### DIFF
--- a/src/api/controllers/activity-controllers.ts
+++ b/src/api/controllers/activity-controllers.ts
@@ -10,4 +10,17 @@ const getAllActivities = async (_: Request, res: Response, next: NextFunction) =
     }
 };
 
-export { getAllActivities };
+const getActivity = async (req: Request, res: Response, next: NextFunction) => {
+    const { activityId } = req.params;
+    try {
+        /** Call to service layer */
+        const result = await activityServices.getActivity(Number(activityId));
+
+        /** Return a response */
+        return res.status(200).json(result);
+    } catch (e) {
+        next(e);
+    }
+};
+
+export { getAllActivities, getActivity };

--- a/src/api/controllers/activity-controllers.ts
+++ b/src/api/controllers/activity-controllers.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response } from 'express';
+import { activityServices } from '../services';
+
+const getAllActivities = async (_: Request, res: Response, next: NextFunction) => {
+    try {
+        const result = await activityServices.getAllActivities();
+        return res.status(200).json(result);
+    } catch (e) {
+        next(e);
+    }
+};
+
+export { getAllActivities };

--- a/src/api/controllers/activity-controllers.ts
+++ b/src/api/controllers/activity-controllers.ts
@@ -1,9 +1,16 @@
 import { NextFunction, Request, Response } from 'express';
 import { activityServices } from '../services';
 
-const getAllActivities = async (_: Request, res: Response, next: NextFunction) => {
+const getAllActivities = async (req: Request, res: Response, next: NextFunction) => {
+    /** Values for response pagination */
+    const page = req.query.page ? Number(req.query.page) : 1;  // DEFAULT _PAGE = 1
+    const size = req.query.size ? Number(req.query.size) : 20; // MAX_PER_PAGE = 20
+
     try {
-        const result = await activityServices.getAllActivities();
+        /** Call to service layer */
+        const result = await activityServices.getAllActivities(page, size);
+
+        /** Paginated response */
         return res.status(200).json(result);
     } catch (e) {
         next(e);

--- a/src/api/controllers/activity-controllers.ts
+++ b/src/api/controllers/activity-controllers.ts
@@ -3,7 +3,7 @@ import { activityServices } from '../services';
 
 const getAllActivities = async (req: Request, res: Response, next: NextFunction) => {
     /** Values for response pagination */
-    const page = req.query.page ? Number(req.query.page) : 1;  // DEFAULT _PAGE = 1
+    const page = req.query.page ? Number(req.query.page) : 1; // DEFAULT _PAGE = 1
     const size = req.query.size ? Number(req.query.size) : 20; // MAX_PER_PAGE = 20
 
     try {

--- a/src/api/controllers/index.ts
+++ b/src/api/controllers/index.ts
@@ -1,2 +1,3 @@
 export * as userController from './user-controllers';
 export * as businessController from './business-controllers';
+export * as activityController from './activity-controllers';

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -1,10 +1,20 @@
 import { Activity } from '../models';
 
-const getAllActivities = async () => {
+/** Get all available Activities with pagination */
+const getAllActivities = async (page: number, size: number) => {
     await Activity.sync();
-    return Activity.findAll();
+    const result = await Activity.findAndCountAll({
+        limit: size,
+        offset: (page - 1) * size
+    });
+    return {
+        ...result,
+        totalPages: Math.ceil(result.count / size),
+        currentPage: page
+    };
 };
 
+/** Get details of a particular Activity using 'id' */
 const getActivity = async (id: number) => {
     await Activity.sync();
     const activity = await Activity.findByPk(id);

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -1,0 +1,8 @@
+import { Activity } from '../models';
+
+const getAllActivities = async () => {
+    await Activity.sync();
+    return Activity.findAll();
+};
+
+export { getAllActivities };

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -5,4 +5,13 @@ const getAllActivities = async () => {
     return Activity.findAll();
 };
 
-export { getAllActivities };
+const getActivity = async (id: number) => {
+    await Activity.sync();
+    const activity = await Activity.findByPk(id);
+    return {
+        found: !!activity,
+        activity: activity
+    };
+};
+
+export { getAllActivities, getActivity };

--- a/src/api/repos/index.ts
+++ b/src/api/repos/index.ts
@@ -1,2 +1,3 @@
 export * as userRepo from './user-repo';
 export * as businessRepo from './business-repo';
+export * as activityRepo from './activity-repo';

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { activityController } from '../controllers';
 
 const router = express.Router();
 
@@ -7,5 +8,8 @@ const router = express.Router();
 router.get('/activity/get/:activityId', (req, res) => {
     res.send(`GET /activity/get/${req.params.activityId}`);
 });
+
+// FIXME: TESTING PURPOSE ONLY
+router.get('/activity/getAllActivities', activityController.getAllActivities);
 
 export default router;

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -1,5 +1,7 @@
 import express from 'express';
 import { activityController } from '../controllers';
+import * as activitySchema from '../schemas/activity-schema';
+import { validate } from '../middlewares/validateResource';
 
 const router = express.Router();
 
@@ -8,6 +10,6 @@ const router = express.Router();
 // FIXME: force activityId to be numerical, might consider using UUID in future
 router.get('/activity/get/:activityId', activityController.getActivity);
 
-router.get('/activity/getFeeds', activityController.getAllActivities);
+router.get('/activity/getFeeds', validate(activitySchema.getFeeds), activityController.getAllActivities);
 
 export default router;

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -5,9 +5,8 @@ const router = express.Router();
 
 /** GET */
 
-router.get('/activity/get/:activityId', (req, res) => {
-    res.send(`GET /activity/get/${req.params.activityId}`);
-});
+// FIXME: force activityId to be numerical, might consider using UUID in future
+router.get('/activity/get/:activityId', activityController.getActivity);
 
 // FIXME: TESTING PURPOSE ONLY
 router.get('/activity/getAllActivities', activityController.getAllActivities);

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -7,8 +7,7 @@ const router = express.Router();
 
 /** GET */
 
-// FIXME: force activityId to be numerical, might consider using UUID in future
-router.get('/activity/get/:activityId', activityController.getActivity);
+router.get('/activity/get/:activityId', validate(activitySchema.getActivity), activityController.getActivity);
 
 router.get('/activity/getFeeds', validate(activitySchema.getFeeds), activityController.getAllActivities);
 

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -8,7 +8,6 @@ const router = express.Router();
 // FIXME: force activityId to be numerical, might consider using UUID in future
 router.get('/activity/get/:activityId', activityController.getActivity);
 
-// FIXME: TESTING PURPOSE ONLY
-router.get('/activity/getAllActivities', activityController.getAllActivities);
+router.get('/activity/getFeeds', activityController.getAllActivities);
 
 export default router;

--- a/src/api/schemas/activity-schema.ts
+++ b/src/api/schemas/activity-schema.ts
@@ -3,9 +3,9 @@ import { invalidMessage, requiredMessage } from './util';
 
 /** Attributes */
 
-const activityId = string({
+const activityId = coerce.number({
     required_error: requiredMessage('Activity ID'),
-    invalid_type_error: invalidMessage('Activity ID', 'string')
+    invalid_type_error: invalidMessage('Activity ID', 'number')
 });
 
 const title = string({
@@ -62,6 +62,12 @@ const activitySchema = object({
     endTime: endTime.optional()
 });
 
+const getActivity = object({
+    params: object({
+        activityId: activityId
+    }).strict('Params contain invalid key')
+});
+
 const getFeeds = object({
     // Query
     query: object({
@@ -82,4 +88,4 @@ const getFeeds = object({
 });
 
 export { activityId, title, description, costPerIndividual, costPerGroup, groupSize, startTime, endTime, address };
-export { activitySchema, getFeeds };
+export { activitySchema, getActivity, getFeeds };

--- a/src/api/schemas/activity-schema.ts
+++ b/src/api/schemas/activity-schema.ts
@@ -62,5 +62,24 @@ const activitySchema = object({
     endTime: endTime.optional()
 });
 
+const getFeeds = object({
+    // Query
+    query: object({
+        // Optional
+        page: coerce
+            .number({
+                invalid_type_error: invalidMessage('Page', 'number')
+            })
+            .gte(1, 'Page has to be greater or equal to 1')
+            .optional(),
+        size: coerce
+            .number({
+                invalid_type_error: invalidMessage('Size', 'number')
+            })
+            .gte(5, 'Size has to be greater or equal to 5')
+            .optional()
+    }).strict('Query contains invalid key')
+});
+
 export { activityId, title, description, costPerIndividual, costPerGroup, groupSize, startTime, endTime, address };
-export { activitySchema };
+export { activitySchema, getFeeds };

--- a/src/api/services/activity-services.ts
+++ b/src/api/services/activity-services.ts
@@ -1,7 +1,7 @@
 import { activityRepo } from '../repos';
 
-const getAllActivities = async () => {
-    return activityRepo.getAllActivities();
+const getAllActivities = async (page: number, size: number) => {
+    return activityRepo.getAllActivities(page, size);
 };
 
 const getActivity = async (id: number) => {

--- a/src/api/services/activity-services.ts
+++ b/src/api/services/activity-services.ts
@@ -4,4 +4,8 @@ const getAllActivities = async () => {
     return activityRepo.getAllActivities();
 };
 
-export { getAllActivities };
+const getActivity = async (id: number) => {
+    return activityRepo.getActivity(id);
+};
+
+export { getAllActivities, getActivity };

--- a/src/api/services/activity-services.ts
+++ b/src/api/services/activity-services.ts
@@ -1,0 +1,7 @@
+import { activityRepo } from '../repos';
+
+const getAllActivities = async () => {
+    return activityRepo.getAllActivities();
+};
+
+export { getAllActivities };

--- a/src/api/services/index.ts
+++ b/src/api/services/index.ts
@@ -1,2 +1,3 @@
 export * as userServices from './user-services';
 export * as businessServices from './business-services';
+export * as activityServices from './activity-services';


### PR DESCRIPTION
## General info

An endpoint to fetch all activities available (unfiltered) from the DB. Pagination is implemented

## Task description

- Get details of an `Activity`
- Get all `Activity`s from DB, unfiltered and **unsorted** (needs update in the future)
- Paginate for smaller-sized response
- Return `totalPages` and `currentPage` for client to keep track
- Apply schemas

## Manual testing

- Pull from branch `PAPILIO-72-feeds`
- Remember to include `.env` and `credentials.json`
- Run `npm install`
- Run `npm run build`
- Run `npm start` to start the server
- Start testing with Postman using this endpoint
![image](https://user-images.githubusercontent.com/59896258/215338930-7f1c68ce-ab04-4203-9e28-c90356f5e31b.png)

### How to use it

- Endpoint: `/api/activity/getFeeds?<optional-queries>`
- Optional queries: `page=<page-value>&size=<size-value>`
- DEFAULT: 
*- `page-value = 1` since first page, has to be >= 1
*- `size-value = 20` has to be >= 5