### PR TITLE
PAPILIO-94 Search endpoint

### DIFF
--- a/src/api/controllers/activity-controllers.ts
+++ b/src/api/controllers/activity-controllers.ts
@@ -36,7 +36,10 @@ const getActivity = async (req: Request, res: Response, next: NextFunction) => {
 const searchActivities = async (req: Request, res: Response, next: NextFunction) => {
     const { keyword } = req.body;
     try {
-        const result = await activityServices.searchActivities(keyword);
+        /** Call to service layer */
+        const result = await activityServices.searchActivities(keyword.trim());
+
+        /** Return a response */
         return res.status(200).json(result);
     } catch (e) {
         next(e);

--- a/src/api/controllers/activity-controllers.ts
+++ b/src/api/controllers/activity-controllers.ts
@@ -33,4 +33,14 @@ const getActivity = async (req: Request, res: Response, next: NextFunction) => {
     }
 };
 
-export { getAllActivities, getActivity };
+const searchActivities = async (req: Request, res: Response, next: NextFunction) => {
+    const { keyword } = req.body;
+    try {
+        const result = await activityServices.searchActivities(keyword);
+        return res.status(200).json(result);
+    } catch (e) {
+        next(e);
+    }
+};
+
+export { getAllActivities, getActivity, searchActivities };

--- a/src/api/controllers/tests/user-controller.test.ts
+++ b/src/api/controllers/tests/user-controller.test.ts
@@ -65,7 +65,6 @@ describe('UserController', () => {
                 //  Act
                 const res = await request(app).get(endpoint);
 
-
                 //  Assert
                 expect(res.statusCode).toBe(expectedStatusCode);
 
@@ -666,8 +665,8 @@ describe('UserController', () => {
             });
             it('should return BADREQUEST[404] if id parameter is missing.', async () => {
                 //  Arrange
-                const badId = ''
-                const endpoint = `/api/user/addActivity/${badId}`;  //  Missing id parameter
+                const badId = '';
+                const endpoint = `/api/user/addActivity/${badId}`; //  Missing id parameter
                 const expectedStatusCode = 404;
                 const userRepoSpy = jest.spyOn(userRepo, 'addNewUserActivity').mockResolvedValueOnce(emptyResultValue);
 
@@ -685,8 +684,6 @@ describe('UserController', () => {
 
                 userRepoSpy.mockRestore();
             });
-            
         });
     });
 });
-

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -36,6 +36,7 @@ const searchActivities = async (keyword: string) => {
             return item.trim().length > 0;
         })
         .join(' & ');
+    console.log(keywordListRepacked);
 
     const MAX_SEARCH_RESULT = 30;
     const queryString =
@@ -43,9 +44,8 @@ const searchActivities = async (keyword: string) => {
         `SELECT A."id", "title", "description", "images"[1]
          FROM "Activities_Tokens_Search" ATS,
               "Activities" A
-         WHERE ("description_tokens" @@ to_tsquery('english', '${keywordListRepacked}')
-             OR "title_tokens" @@ to_tsquery('english', '${keywordListRepacked}')
-             )
+         WHERE 
+           ATS."tokens" @@ to_tsquery('english', '${keywordListRepacked}')
            AND ATS."id" = A."id"
          ORDER BY "startTime" DESC
          LIMIT ${MAX_SEARCH_RESULT}

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -1,4 +1,6 @@
 import { Activity } from '../models';
+import sequelize from '../../config/sequelize';
+import { queryResultError } from './error';
 
 /** Get all available Activities with pagination */
 const getAllActivities = async (page: number, size: number) => {
@@ -24,4 +26,24 @@ const getActivity = async (id: number) => {
     };
 };
 
-export { getAllActivities, getActivity };
+const searchActivities = async (keyword: string) => {
+    const queryString =
+        // QUERY TO SEARCH FOR ACTIVITIES USING FULL-TEXT SEARCH
+        `SELECT A."id", "title", "description", "images"[1]
+         FROM "Activities_Tokens_Search" ATS,
+              "Activities" A
+         WHERE ("description_tokens" @@ to_tsquery('english', '${keyword}')
+             OR "title_tokens" @@ to_tsquery('english', '${keyword}')
+             )
+           AND ATS."id" = A."id"
+         ORDER BY "startTime" DESC
+        `;
+    const [rows, _] = await sequelize.query(queryString).catch((err) => queryResultError(err, 'searchActivities'));
+    return {
+        keyword: keyword,
+        count: rows.length,
+        rows: rows
+    };
+};
+
+export { getAllActivities, getActivity, searchActivities };

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -33,10 +33,9 @@ const searchActivities = async (keyword: string) => {
     const keywordListRepacked = keyword
         .split(' ')
         .filter((item) => {
-            return item.trim().length > 0;
+            return item.trim().length > 1; // Remove meaningless empty or 1-letter words
         })
         .join(' & ');
-    console.log(keywordListRepacked);
 
     const MAX_SEARCH_RESULT = 30;
     const queryString =

--- a/src/api/repos/error.ts
+++ b/src/api/repos/error.ts
@@ -3,7 +3,8 @@ import { APIError } from '../../errors/api-error';
 import { httpStatusCode } from '../../types/httpStatusCodes';
 import { BaseError } from '../../errors/base-error';
 
-/** Catching error */
+/** Catching errors */
+
 const createNewObjectCaughtError = (error: any, methodName: string, message?: string) => {
     console.log(error);
     if (error.name === 'SequelizeUniqueConstraintError') {
@@ -15,4 +16,9 @@ const createNewObjectCaughtError = (error: any, methodName: string, message?: st
     } else throw new BaseError('ORM Sequelize Error', message ? message : 'There has been an error in the DB', methodName, httpStatusCode.INTERNAL_SERVER, true);
 };
 
-export { createNewObjectCaughtError };
+const queryResultError = (error: any, methodName: string, message?: string) => {
+    console.log(error);
+    throw new BaseError('ORM Sequelize Error', message ? message : 'Error in query execution in the DB', methodName, httpStatusCode.INTERNAL_SERVER, true);
+};
+
+export { createNewObjectCaughtError, queryResultError };

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -11,6 +11,6 @@ router.get('/activity/get/:activityId', validate(activitySchema.getActivity), ac
 
 router.get('/activity/getFeeds', validate(activitySchema.getFeeds), activityController.getAllActivities);
 
-router.get('/activity/search', activityController.searchActivities);
+router.get('/activity/search', validate(activitySchema.searchActivities), activityController.searchActivities);
 
 export default router;

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -11,4 +11,6 @@ router.get('/activity/get/:activityId', validate(activitySchema.getActivity), ac
 
 router.get('/activity/getFeeds', validate(activitySchema.getFeeds), activityController.getAllActivities);
 
+router.get('/activity/search', activityController.searchActivities);
+
 export default router;

--- a/src/api/schemas/activity-schema.ts
+++ b/src/api/schemas/activity-schema.ts
@@ -87,5 +87,15 @@ const getFeeds = object({
     }).strict('Query contains invalid key')
 });
 
+const searchActivities = object({
+    body: object({
+        // Required
+        keyword: string({
+            required_error: requiredMessage('Keyword'),
+            invalid_type_error: invalidMessage('Keyword', 'string')
+        })
+    }).strict('Body contains invalid key')
+})
+
 export { activityId, title, description, costPerIndividual, costPerGroup, groupSize, startTime, endTime, address };
-export { activitySchema, getActivity, getFeeds };
+export { activitySchema, getActivity, getFeeds, searchActivities };

--- a/src/api/services/activity-services.ts
+++ b/src/api/services/activity-services.ts
@@ -8,4 +8,8 @@ const getActivity = async (id: number) => {
     return activityRepo.getActivity(id);
 };
 
-export { getAllActivities, getActivity };
+const searchActivities = async (keyword: string) => {
+    return activityRepo.searchActivities(keyword);
+};
+
+export { getAllActivities, getActivity, searchActivities };


### PR DESCRIPTION
## General info

An endpoint for searching the activity DB.

## Task description

Implemented PostgreSQL full text search in DB
- Added a new table to store text-search (ts) tokens
- Added trigger on `Activity` table to update on token table after UPDATE, INSERT or DELETE
- Parsed tokens from **both** `title` and `description`
- Applied default `'english'` engine (this could/should be improved)

Implemented endpoint in backend
- Applied raw SQL with Sequelize
- Returns `count` and `rows` (results from the SQL)

## Manual testing / Usage instruction

### Request from client

Endpoint: `/api/activity/search`

Request body: `keyword` as a string of words

### Response from server

`keyword`: string - replica of provided keyword string

`count`: number of results

`rows`: results, where each object contains `id` (integer), `title` (string), `description` (string), `images` (string, link of first image)

![image](https://user-images.githubusercontent.com/59896258/219834983-d2067b97-6aa7-47bf-9392-310bce6e09dd.png)


## Note

Ping me if you have any problem or find any issue