### PR TITLE
Search: GET -> POST

### DIFF
--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -13,6 +13,6 @@ router.get('/activity/getFeeds', validate(activitySchema.getFeeds), activityCont
 
 router.post('/activity/update/:activityId', validate(activitySchema.updateActivity), activityController.updateActivity);
 
-router.get('/activity/search', validate(activitySchema.searchActivities), activityController.searchActivities);
+router.post('/activity/search', validate(activitySchema.searchActivities), activityController.searchActivities);
 
 export default router;


### PR DESCRIPTION
Search endpoint has been changed from GET to POST as a workaround to the Retrofit limitation of not being able to send a BODY with a GET request. 