### PR TITLE
PAPILIO-104 Add Email to Activity

### DIFF
--- a/src/api/controllers/activity-controllers.ts
+++ b/src/api/controllers/activity-controllers.ts
@@ -22,9 +22,10 @@ const getAllActivities = async (req: Request, res: Response, next: NextFunction)
 
 const getActivity = async (req: Request, res: Response, next: NextFunction) => {
     const { activityId } = req.params;
+    const contact = !!Number(req.query.contact);
     try {
         /** Call to service layer */
-        const result = await activityServices.getActivity(Number(activityId));
+        const result = await activityServices.getActivity(Number(activityId), contact);
 
         /** Return a response */
         return res.status(200).json(result);

--- a/src/api/controllers/tests/activity-controller.test.ts
+++ b/src/api/controllers/tests/activity-controller.test.ts
@@ -1,0 +1,100 @@
+import request from 'supertest';
+import app, { server } from '../../../app';
+import { activityRepo } from '../../repos';
+
+jest.mock('sequelize');
+
+describe('ActivityController', () => {
+    afterEach(() => {
+        server.close();
+    });
+
+    const mockActivityId = 70;
+    const mockActivity = {
+        id: 70,
+        title: 'Title of Activity',
+        description: 'Description of the current Activity',
+        images: [],
+        address: '1234 Rue Guy, Montreal, QC EXM PLE'
+    };
+
+    describe('GET /activity', () => {
+        describe('getActivity endpoint', () => {
+            it('should return OK[200] and a valid response if Activity found', async () => {
+                // Arrange
+                const endpoint = `/api/activity/get/${mockActivityId}`;
+                const expectedStatusCode = 200;
+                const activityRepoGetActivitySpy = jest.spyOn(activityRepo, 'getActivity').mockResolvedValueOnce({
+                    found: true,
+                    // @ts-ignore 'activity' missing other attributes, doesn't matter
+                    activity: mockActivity
+                });
+
+                // Act
+                const response = await request(app).get(endpoint);
+
+                // Assert
+                expect(activityRepoGetActivitySpy).toHaveBeenCalledTimes(1);
+                expect(activityRepoGetActivitySpy).toHaveBeenCalledWith(mockActivityId, false);
+                expect(response.statusCode).toEqual(expectedStatusCode);
+                expect(response.body.found).toBeTruthy();
+                expect(response.body.activity).toEqual(mockActivity);
+
+                activityRepoGetActivitySpy.mockRestore();
+            });
+
+            it('should return OK[200] and null activity if Activity not found', async () => {
+                // Arrange
+                const notFoundActivityId = 2;
+                const endpoint = `/api/activity/get/${notFoundActivityId}`;
+                const expectedStatusCode = 200;
+                const activityRepoGetActivitySpy = jest.spyOn(activityRepo, 'getActivity').mockResolvedValueOnce({
+                    found: false,
+                    activity: null
+                });
+
+                // Act
+                const response = await request(app).get(endpoint);
+
+                // Assert
+                expect(activityRepoGetActivitySpy).toHaveBeenCalledTimes(1);
+                expect(activityRepoGetActivitySpy).toHaveBeenCalledWith(notFoundActivityId, false);
+                expect(response.statusCode).toEqual(expectedStatusCode);
+                expect(response.body.found).toBeFalsy();
+                expect(response.body.activity).toBeNull();
+
+                activityRepoGetActivitySpy.mockRestore();
+            });
+
+            it('should return OK[200] and a valid response with contact info if Activity found', async () => {
+                // Arrange
+                const endpoint = `/api/activity/get/${mockActivityId}?contact=1`;
+                const expectedStatusCode = 200;
+                const activityRepoGetActivitySpy = jest.spyOn(activityRepo, 'getActivity').mockResolvedValueOnce({
+                    found: true,
+                    activity: {
+                        ...mockActivity,
+                        // @ts-ignore 'activity' adding other attributes, doesn't matter
+                        user: null,
+                        business: {
+                            businessId: 'something',
+                            email: 'contact@something.com'
+                        }
+                    }
+                });
+
+                // Act
+                const response = await request(app).get(endpoint);
+
+                // Assert
+                expect(activityRepoGetActivitySpy).toHaveBeenCalledTimes(1);
+                expect(activityRepoGetActivitySpy).toHaveBeenCalledWith(mockActivityId, true); // 'true' mandatory
+                expect(response.statusCode).toEqual(expectedStatusCode);
+                expect(response.body.found).toBeTruthy();
+                expect(response.body.activity.business).toBeDefined();
+
+                activityRepoGetActivitySpy.mockRestore();
+            });
+        });
+    });
+});

--- a/src/api/models/Activity.ts
+++ b/src/api/models/Activity.ts
@@ -142,6 +142,11 @@ Activity.hasMany(ActivityReview, {
     foreignKey: 'activityId',
     sourceKey: 'id'
 });
+ActivityReview.belongsTo(Activity, {
+    as: 'activity',
+    foreignKey: 'activityId',
+    targetKey: 'id'
+});
 
 Activity.belongsToMany(Genre, { through: Activity_Genres });
 

--- a/src/api/models/Business.ts
+++ b/src/api/models/Business.ts
@@ -84,5 +84,10 @@ Business.hasMany(Activity, {
     foreignKey: 'businessId',
     sourceKey: 'businessId'
 });
+Activity.belongsTo(Business, {
+    as: 'business',
+    foreignKey: 'businessId',
+    targetKey: 'businessId'
+});
 
 export { Business };

--- a/src/api/models/Business.ts
+++ b/src/api/models/Business.ts
@@ -78,6 +78,11 @@ Business.hasMany(Employee, {
     foreignKey: 'businessId',
     sourceKey: 'businessId'
 });
+Employee.belongsTo(Business, {
+    as: 'business',
+    foreignKey: 'businessId',
+    targetKey: 'businessId'
+});
 
 Business.hasMany(Activity, {
     as: 'activities',

--- a/src/api/models/User.ts
+++ b/src/api/models/User.ts
@@ -126,6 +126,11 @@ User.hasMany(ActivityReview, {
     foreignKey: 'userId',
     sourceKey: 'id'
 });
+ActivityReview.belongsTo(User, {
+    as: 'user',
+    foreignKey: 'userId',
+    targetKey: 'id'
+});
 
 User.hasMany(Activity, {
     as: 'activities',
@@ -139,5 +144,6 @@ Activity.belongsTo(User, {
 });
 
 User.hasOne(Quiz, { sourceKey: 'firebase_id' });
+Quiz.belongsTo(User, { targetKey: 'firebase_id' });
 
 export { User };

--- a/src/api/models/User.ts
+++ b/src/api/models/User.ts
@@ -132,6 +132,11 @@ User.hasMany(Activity, {
     foreignKey: 'userId',
     sourceKey: 'firebase_id'
 });
+Activity.belongsTo(User, {
+    as: 'user',
+    foreignKey: 'userId',
+    targetKey: 'firebase_id'
+});
 
 User.hasOne(Quiz, { sourceKey: 'firebase_id' });
 

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -1,4 +1,4 @@
-import { Activity } from '../models';
+import { Activity, Business, User } from '../models';
 import { BaseError } from '../../errors/base-error';
 import { httpStatusCode } from '../../types/httpStatusCodes';
 import sequelize from '../../config/sequelize';
@@ -19,9 +19,27 @@ const getAllActivities = async (page: number, size: number) => {
 };
 
 /** Get details of a particular Activity using 'id' */
-const getActivity = async (id: number) => {
+const getActivity = async (id: number, contact: boolean) => {
     await Activity.sync();
-    const activity = await Activity.findByPk(id);
+    const activity = contact
+        ? await Activity.findByPk(id, {
+              attributes: { exclude: ['businessId', 'userId', 'createdAt', 'updatedAt'] },
+              include: [
+                  {
+                      model: Business,
+                      attributes: ['businessId', 'email'], // customizable
+                      as: 'business'
+                  },
+                  {
+                      model: User,
+                      attributes: ['id', 'email'], // customizable
+                      as: 'user'
+                  }
+              ]
+          })
+        : await Activity.findByPk(id, {
+              attributes: { exclude: ['businessId', 'userId', 'createdAt', 'updatedAt'] }
+          });
     return {
         found: !!activity,
         activity: activity

--- a/src/api/services/activity-services.ts
+++ b/src/api/services/activity-services.ts
@@ -4,8 +4,8 @@ const getAllActivities = async (page: number, size: number) => {
     return activityRepo.getAllActivities(page, size);
 };
 
-const getActivity = async (id: number) => {
-    return activityRepo.getActivity(id);
+const getActivity = async (id: number, contact: boolean = false) => {
+    return activityRepo.getActivity(id, contact);
 };
 
 const updateActivity = async (id: number, update: any) => {


### PR DESCRIPTION
## General info

Need `email` for the Activity retrieved from database.

## Task description

- Added complement relations to the existing ones between the models
- Added `businesss` and `user` attribute to the return response
- Made `business` and `user` optional depending on the URL
- Added some tests for this method
- Added some tests for some other methods (unrelated)

## Manual testing

Original URL: GET `/activity/get/<activity-id-here>`

optional `contact` returns URL: GET `/activity/get/<activity-id-here>?contact=<contact-choice>`

contact-choice: 

- `1` or any non-zero number --> true --> will return `business` and `user`
- `0` or original URL --> false --> will NOT return `business` and `user`

![image](https://user-images.githubusercontent.com/59896258/223914064-81972d27-35e9-49ff-bbb5-d6b002bf9421.png)

## Result

`localhost:1337/api/activity/get/:activityId?contact=-1`

![image](https://user-images.githubusercontent.com/59896258/223914508-319abc8b-02fc-484c-ae88-aa5d12fbb228.png)

`localhost:1337/api/activity/get/:activityId`

## Note

Test it out and let me know if there's any problem

![image](https://user-images.githubusercontent.com/59896258/223914557-c5d2a0c4-a94c-42a7-b5db-9640f1f256e5.png)

