### PR TITLE
PAPILIO-92: Feeds improve

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "test:watch": "jest src/ --runInBand --detectOpenHandles --watchAll --forceExit --coverage",
         "test:watch1": "jest src/api/controllers/tests/user-controller.test.ts --runInBand --detectOpenHandles --watchAll --forceExit",
         "test:watch2": "jest src/api/controllers/tests/business-controller.test.ts --runInBand --detectOpenHandles --watchAll --forceExit",
+        "test:watch3": "jest src/api/controllers/tests/activity-controller.test.ts --runInBand --detectOpenHandles --watchAll --forceExit",
         "dev": "tsc-watch --onSuccess \"node dist/app.js\"",
         "lint": "eslint ./**/*.ts --fix",
         "prettier": "prettier --write src/",

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -23,7 +23,7 @@ const getAllActivities = async (page: number, size: number) => {
                 as: 'user'
             }
         ]
-    });
+    }).catch((e) => queryResultError(e, 'getAllActivities'));
     return {
         ...result,
         totalPages: Math.ceil(result.count / size),
@@ -49,10 +49,10 @@ const getActivity = async (id: number, contact: boolean) => {
                       as: 'user'
                   }
               ]
-          })
+          }).catch((e) => queryResultError(e, 'getActivitiy'))
         : await Activity.findByPk(id, {
               attributes: { exclude: ['businessId', 'userId', 'createdAt', 'updatedAt'] }
-          });
+          }).catch((e) => queryResultError(e, 'getActivity'));
     return {
         found: !!activity,
         activity: activity

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -9,7 +9,20 @@ const getAllActivities = async (page: number, size: number) => {
     await Activity.sync();
     const result = await Activity.findAndCountAll({
         limit: size,
-        offset: (page - 1) * size
+        offset: (page - 1) * size,
+        attributes: { exclude: ['businessId', 'userId', 'createdAt', 'updatedAt'] },
+        include: [
+            {
+                model: Business,
+                attributes: ['businessId', 'email'],
+                as: 'business'
+            },
+            {
+                model: User,
+                attributes: ['id', 'email'],
+                as: 'user'
+            }
+        ]
     });
     return {
         ...result,
@@ -23,7 +36,7 @@ const getActivity = async (id: number, contact: boolean) => {
     await Activity.sync();
     const activity = contact
         ? await Activity.findByPk(id, {
-              attributes: { exclude: ['businessId', 'userId', 'createdAt', 'updatedAt'] },
+              attributes: { exclude: ['businessId', 'userId'] },
               include: [
                   {
                       model: Business,


### PR DESCRIPTION
## General

- Some small improvements to the feeds endpoint response
- No filter added even though mentioned originally in the ticket. Communicated with the front-end team.

## Task description

- [x]  Similar to #34 
- [x]  Add some more tests for activityController

## Manual testing

Use the same route `localhost:1337/api/activity/getFeeds?size=5&page=3`. Should receive the newly-adjusted fields in each of the Activity in `rows`.

![image](https://user-images.githubusercontent.com/59896258/224149719-30ffede6-936d-4164-afbe-4941026860ad.png)

## Notes

n/a