### PR TITLE
Create stream chat user upon user sign up

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# General info
+
+**Issue number**: 
+
+**Task description**:
+ - 
+ - 
+
+# Testing
+To test this feature you have to:
+
+1. Step 1
+2. Step 2
+3. Step 3
+4. Step 4
+
+# Notes
+- Note 1
+- Note 2

--- a/src/api/controllers/user-controllers.ts
+++ b/src/api/controllers/user-controllers.ts
@@ -21,6 +21,7 @@ const createUser = async (req: Request, res: Response, next: NextFunction) => {
     try {
         /** Call to service layer */
         const statusCode = await userServices.createUser(user);
+        await userServices.createNewStreamChatUser(user.firebase_id, user.firstName + " " + user.lastName);
 
         /** Return a response to client. */
         return res.sendStatus(statusCode);

--- a/src/api/controllers/user-controllers.ts
+++ b/src/api/controllers/user-controllers.ts
@@ -21,7 +21,7 @@ const createUser = async (req: Request, res: Response, next: NextFunction) => {
     try {
         /** Call to service layer */
         const statusCode = await userServices.createUser(user);
-        await userServices.createNewStreamChatUser(user.firebase_id, user.firstName + " " + user.lastName);
+        if (statusCode == httpStatusCode.CREATED) await userServices.createNewStreamChatUser(user.firebase_id, user.firstName + " " + user.lastName);
 
         /** Return a response to client. */
         return res.sendStatus(statusCode);

--- a/src/api/services/__mocks__/user-services.ts
+++ b/src/api/services/__mocks__/user-services.ts
@@ -54,9 +54,8 @@ const removeMemberFromActivityChat = async (user_id: string, channel_id: string)
     return userRepo.removeMemberFromActivityChat(user_id, channel_id);
 };
 
-const createNewStreamChatUser = async (user_id: string, user_name: string) => {
-    return userRepo.createNewStreamChatUser(user_id, user_name);
-};
+// @ts-ignore
+const createNewStreamChatUser = async (user_id: string, user_name: string) => jest.fn(() => console.log('called mock createNewStreamChatUser'));
 
 const checkJoinedActivity = async (id: string, activityId: number) => {
     return userRepo.checkJoinedActivity(id, activityId);


### PR DESCRIPTION
# General info

**Issue number**: Bug fix

**Task description**: 
 - Chat users need to be create separately from the firebase users. Errors will occur while using the chat feature on android if a stream chat user is not created for the current firebase user. Thus, creating firebase and stream users is necessary for the proper functionality of the mobile application.

# Testing
To test this feature you have to:

1. Create a new user with postman and check if that user appear both in the database and in the stream chat dashboard

# Notes
- I also added  a PR template for future pull requests in order to be consistent
- A quick look at the code should be enough, I tested everything
