### PR TITLE
PAPILIO-113 Closing Activity

### DIFF
--- a/src/api/controllers/activity-controllers.ts
+++ b/src/api/controllers/activity-controllers.ts
@@ -48,6 +48,26 @@ const updateActivity = async (req: Request, res: Response, next: NextFunction) =
     }
 };
 
+const closeActivity = async (req: Request, res: Response, next: NextFunction) => {
+    const { activityId } = req.params;
+    try {
+        const result = await activityServices.closeActivity(Number(activityId));
+        return res.status(200).json(result);
+    } catch (e) {
+        next(e);
+    }
+};
+
+const openActivity = async (req: Request, res: Response, next: NextFunction) => {
+    const { activityId } = req.params;
+    try {
+        const result = await activityServices.openActivity(Number(activityId));
+        return res.status(200).json(result);
+    } catch (e) {
+        next(e);
+    }
+};
+
 const searchActivities = async (req: Request, res: Response, next: NextFunction) => {
     const { keyword } = req.body;
     try {
@@ -61,4 +81,4 @@ const searchActivities = async (req: Request, res: Response, next: NextFunction)
     }
 };
 
-export { getAllActivities, getActivity, searchActivities, updateActivity };
+export { getAllActivities, getActivity, searchActivities, updateActivity, closeActivity, openActivity };

--- a/src/api/models/Activity.ts
+++ b/src/api/models/Activity.ts
@@ -34,6 +34,7 @@ class Activity extends Model<InferAttributes<Activity, { omit: 'activityReviews'
     declare startTime: Date | null;
     declare endTime: Date | null;
     declare address: string;
+    declare closed: boolean;
 
     declare activityReviews?: NonAttribute<ActivityReview[]>;
 
@@ -101,6 +102,10 @@ Activity.init(
         address: {
             type: DataTypes.STRING,
             allowNull: false
+        },
+        closed: {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false
         }
     },
     {

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -60,7 +60,7 @@ const getActivity = async (id: number, contact: boolean) => {
 };
 
 /** Update details of the Activity */
-const updateActivity = async (id: number, update: any) => {
+const updateActivity = async (id: number, update: any, returning = true) => {
     await Activity.sync();
     const result = await Activity.update(update, {
         where: { id },
@@ -69,10 +69,12 @@ const updateActivity = async (id: number, update: any) => {
         console.log(err);
         throw new BaseError('ORM Sequelize Error', 'There has been an error in updating the Activity', 'updateActivity', httpStatusCode.INTERNAL_SERVER, true);
     });
-    return {
-        success: !!result,
-        activity: result[1][0]
-    };
+    if (returning)
+        return {
+            success: !!result,
+            activity: result[1][0]
+        };
+    else return { success: !!result };
 };
 
 /** Search for Activities using the provided 'keyword' */

--- a/src/api/repos/activity-repo.ts
+++ b/src/api/repos/activity-repo.ts
@@ -3,6 +3,7 @@ import { BaseError } from '../../errors/base-error';
 import { httpStatusCode } from '../../types/httpStatusCodes';
 import sequelize from '../../config/sequelize';
 import { queryResultError } from './error';
+import { APIError } from '../../errors/api-error';
 
 /** Get all available Activities with pagination */
 const getAllActivities = async (page: number, size: number) => {
@@ -69,12 +70,13 @@ const updateActivity = async (id: number, update: any, returning = true) => {
         console.log(err);
         throw new BaseError('ORM Sequelize Error', 'There has been an error in updating the Activity', 'updateActivity', httpStatusCode.INTERNAL_SERVER, true);
     });
+    if (result[0] == 0) throw new APIError(`Cannot find Activity with id ${id}`, 'updateActivity', httpStatusCode.CONFLICT);
     if (returning)
         return {
-            success: !!result,
+            success: true,
             activity: result[1][0]
         };
-    else return { success: !!result };
+    else return { success: true };
 };
 
 /** Search for Activities using the provided 'keyword' */

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -15,4 +15,8 @@ router.post('/activity/update/:activityId', validate(activitySchema.updateActivi
 
 router.post('/activity/search', validate(activitySchema.searchActivities), activityController.searchActivities);
 
+router.post('/activity/close/:activityId', validate(activitySchema.closeActivity), activityController.closeActivity);
+
+router.post('/activity/open/:activityId', validate(activitySchema.closeActivity), activityController.openActivity);
+
 export default router;

--- a/src/api/schemas/activity-schema.ts
+++ b/src/api/schemas/activity-schema.ts
@@ -117,5 +117,7 @@ const searchActivities = object({
     }).strict('Body contains invalid key')
 });
 
+const closeActivity = getActivity;
+
 export { activityId, title, description, costPerIndividual, costPerGroup, groupSize, startTime, endTime, address };
-export { activitySchema, getActivity, getFeeds, searchActivities, updateActivity };
+export { activitySchema, getActivity, getFeeds, searchActivities, updateActivity, closeActivity };

--- a/src/api/services/activity-services.ts
+++ b/src/api/services/activity-services.ts
@@ -16,4 +16,12 @@ const searchActivities = async (keyword: string) => {
     return activityRepo.searchActivities(keyword);
 };
 
-export { getAllActivities, getActivity, searchActivities, updateActivity };
+const closeActivity = async (id: number) => {
+    return activityRepo.updateActivity(id, { closed: true }, false);
+};
+
+const openActivity = async (id: number) => {
+    return activityRepo.updateActivity(id, { closed: false }, false);
+};
+
+export { getAllActivities, getActivity, searchActivities, updateActivity, closeActivity, openActivity };


### PR DESCRIPTION
## General

2 new routes for closing and opening an existing Activity

## Usage

It's assumed that the Activity (i.e. activityId) already existed. If not, error will be thrown identical to getActivity route.

Opening: `/api/activity/open/:activityId`

Closing: `/api/activity/close/:activityId`

## Testing

Manual