### PR TITLE
PAPILIO-102 Update Activity Images

### DIFF
--- a/src/api/controllers/activity-controllers.ts
+++ b/src/api/controllers/activity-controllers.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { activityServices } from '../services';
+import { uploadImageFirebase } from '../../config/storage';
 
 const DEFAULT_PAGE = 1;
 const MAX_PER_PAGE = 20;
@@ -68,6 +69,31 @@ const openActivity = async (req: Request, res: Response, next: NextFunction) => 
     }
 };
 
+const updateActivityImages = async (req: Request, res: Response, next: NextFunction) => {
+    const { activityId } = req.params;
+    try {
+        /** Check if middleware uploaded and retrieved the images' URLs */
+        const imageUrls: string[] = [];
+        if (req.files) {
+            const fileKeys = Object.keys(req.files);
+            for (const key of fileKeys) {
+                // @ts-ignore - THIS IS NECESSARY
+                const url = await uploadImageFirebase(req.files[key]);
+                imageUrls.push(url);
+            }
+        }
+        const update = { images: imageUrls };
+
+        /** Call to service layer */
+        const result = await activityServices.updateActivity(Number(activityId), update);
+
+        /** Return a response to client */
+        return res.status(200).json(result);
+    } catch (e) {
+        next(e);
+    }
+};
+
 const searchActivities = async (req: Request, res: Response, next: NextFunction) => {
     const { keyword } = req.body;
     try {
@@ -81,4 +107,5 @@ const searchActivities = async (req: Request, res: Response, next: NextFunction)
     }
 };
 
-export { getAllActivities, getActivity, searchActivities, updateActivity, closeActivity, openActivity };
+export { getAllActivities, getActivity, searchActivities, updateActivity, closeActivity, openActivity, updateActivityImages };
+

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { activityController } from '../controllers';
 import * as activitySchema from '../schemas/activity-schema';
 import { validate } from '../middlewares/validateResource';
+import { upload } from '../middlewares/multerUpload';
 
 const router = express.Router();
 
@@ -12,6 +13,8 @@ router.get('/activity/get/:activityId', validate(activitySchema.getActivity), ac
 router.get('/activity/getFeeds', validate(activitySchema.getFeeds), activityController.getAllActivities);
 
 router.post('/activity/update/:activityId', validate(activitySchema.updateActivity), activityController.updateActivity);
+
+router.post('/activity/updateImages/:activityId', [upload.array('images', 5)], activityController.updateActivityImages);
 
 router.post('/activity/search', validate(activitySchema.searchActivities), activityController.searchActivities);
 

--- a/src/api/routes/activity-routes.ts
+++ b/src/api/routes/activity-routes.ts
@@ -14,7 +14,7 @@ router.get('/activity/getFeeds', validate(activitySchema.getFeeds), activityCont
 
 router.post('/activity/update/:activityId', validate(activitySchema.updateActivity), activityController.updateActivity);
 
-router.post('/activity/updateImages/:activityId', [upload.array('images', 5)], activityController.updateActivityImages);
+router.post('/activity/updateImages/:activityId', [upload.array('images', 5), validate(activitySchema.updateActivityImages)], activityController.updateActivityImages);
 
 router.post('/activity/search', validate(activitySchema.searchActivities), activityController.searchActivities);
 

--- a/src/api/schemas/activity-schema.ts
+++ b/src/api/schemas/activity-schema.ts
@@ -107,6 +107,8 @@ const updateActivity = object({
     }).strict('Body contains invalid key')
 });
 
+const updateActivityImages = getActivity;
+
 const searchActivities = object({
     body: object({
         // Required
@@ -120,4 +122,4 @@ const searchActivities = object({
 const closeActivity = getActivity;
 
 export { activityId, title, description, costPerIndividual, costPerGroup, groupSize, startTime, endTime, address };
-export { activitySchema, getActivity, getFeeds, searchActivities, updateActivity, closeActivity };
+export { activitySchema, getActivity, getFeeds, searchActivities, updateActivity, closeActivity, updateActivityImages };


### PR DESCRIPTION
## Description

Endpoint to update images for an Activity

## Usage

![image](https://user-images.githubusercontent.com/59896258/229331289-7f3ef445-3484-4add-b1ab-0ceb87462c02.png)

Every time the route is called, the previous array of image urls in the DB will be wiped and replaced with the urls of the new images from the input.

## Testing

Manual

## Issue

Input validation is not working properly at the moment. For now, please use just `images` in a form-data for the input